### PR TITLE
Get rid of GC Collect

### DIFF
--- a/LibCSG-Runtime/CSGBrushOperation.cs
+++ b/LibCSG-Runtime/CSGBrushOperation.cs
@@ -93,7 +93,6 @@ public class CSGBrushOperation
         Array.Clear(merged_brush.faces, 0 , merged_brush.faces.Length);
         mesh_merge.do_operation(operation, ref merged_brush);
         mesh_merge=null;
-        System.GC.Collect();
     }
 
     


### PR DESCRIPTION
This causes a stutter and should not be used anyways, it's good practice to not force garbage collection.